### PR TITLE
Fixed weird pixel-scaling issue for weird screens

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -29,8 +29,6 @@ a, a:visited {
 }
 
 .mapartimg {
-  height: 128px;
-  width: 128px;
   cursor: pointer;
   display: inline-block;
   image-rendering: auto;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
     <meta property="og:image" content="https://rebane2001.com/mapartwall/preview.png">
     <meta property="og:url" content="https://rebane2001.com/mapartwall/">
     <link rel="stylesheet" href="css/app.css">
-    <script src="js/app.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+	<script src="js/app.js" type="text/javascript"></script>
     <script src="https://mapartwall.rebane2001.com/hashes.js" type="text/javascript"></script>
   </head>
   <body>

--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,8 @@ function renderMaps(maps) {
     imgblock += `<img src="https://mapartwall.rebane2001.com/mapimg/map_${maps[i]}.png?v=${lastupdated}" loading="lazy" class="mapartimg" width="128" height="128" title="ID: ${maps[i]}" alt="ID: ${maps[i]}" onclick="mapClick(${maps[i]})" onerror="reloadImage(this)" />`;
   }
   document.getElementById('maparts').innerHTML = imgblock;
+  $(".mapartimg").attr("height", 128/window.devicePixelRatio);
+  $(".mapartimg").attr("width", 128/window.devicePixelRatio);
 }
 
 function mapClick(id) {


### PR DESCRIPTION
I fixed the image scaling for when the device pixel ratio isn't 1, just like Rebane did on mapartcraft a while ago.

Here's a description of the changes:
Removed the width and height from the mapartimg class in app.css because javascript handles the width and height.
Added jQuery from Google's CDN.
Added a line which uses jQuery to change the width and height for all elements with the mapartimg class to 128/window.devicePixelRatio.